### PR TITLE
Update python and remove deprecated output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.17-alpine3.10
+FROM python:3.11.2-alpine3.17
 
 COPY entrypoint.sh /entrypoint.sh
 COPY gen.py /gen.py

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generates an ECS task definition from a template file and a JSON list of secrets
 
 ## Usage
 
-```
+```yml
 jobs:
   deploy:
     steps:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,4 +18,4 @@ output="output-${template_no_slashes}.json"
   -a RELEASE=$parsed_tag \
   > $output
 
-echo ::set-output name=file::$output
+echo "file=${output}" >> $GITHUB_OUTPUT

--- a/gen.py
+++ b/gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """
 Parses a python template file using a given JSON dictionary
 """


### PR DESCRIPTION
### Why:
Github will be deprecating `set-output` command. To avoid any further issues, we should update it. More info [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
Also updated python version to latest.